### PR TITLE
Feature - Error Traps

### DIFF
--- a/EMMS_Code_CommandBoard.X/PowerMain.c
+++ b/EMMS_Code_CommandBoard.X/PowerMain.c
@@ -563,9 +563,9 @@ void powerOnCheckForAllocationReset( void )
 	// Comparing to see if power was restored before or after the expected reset
 	// Check date (resets if later month, later day in month, or new year)
 	if( ( restoreMonth > resetTempTimeMonth ) ||
-		( ( restoreMonth == resetTempTimeMonth ) && ( restoreDay > resetTempTimeDay ) ) ||
-		( restoreMonth < resetTempTimeMonth )
-		)
+	 ( ( restoreMonth == resetTempTimeMonth ) && ( restoreDay > resetTempTimeDay ) ) ||
+	 ( restoreMonth < resetTempTimeMonth )
+	 )
 	{
 
 		resetNeeded = true;
@@ -725,3 +725,61 @@ void relayControl( void )
 
 	return;
 }
+
+
+
+/******************
+ The following are error traps which will prevent the PIC from resetting most of the time
+ They simply return back to the program
+ This doesn't solve the problem, but it prevents the meter from resetting
+ There is a potential that some data corruption may have occurred, but most of the time it will work itself out
+ ***********************/
+#if ERROR_TRAP_INTERRUPTS_ACTIVE == true
+
+void __attribute__( ( interrupt, no_auto_psv ) ) _OscillatorFail( void )
+{
+	INTCON1bits.OSCFAIL = 0; //Clear the trap flag
+
+	return;
+}
+
+void __attribute__( ( interrupt, no_auto_psv ) ) _AddressError( void )
+{
+	// if lEDS are put in debug mode one can count or toggle LEDS to show one of these routines was entered
+
+	// debug methods
+	// place a debug breakpoint in this function to stop execution
+	// then line-by-line execute to get back to the function which caused the error
+	// it will return to the next executing line
+	// to get the actual line where the error occurred, you need to use the getErrLoc function
+	//  getErrLoc is in an assembly ASM file
+	//  this is a file which needs to be added to the project
+	// then it can retrieve the actual instruction where the error occurred 
+	// the errLoc return is a function pointer which can be called to return to the line where the error occurred
+
+	//		errLoc = getErrLoc();	// get the location of error function
+
+
+	INTCON1bits.ADDRERR = 0; //Clear the trap flag
+
+	//	errLoc();		// return to error function directly
+	// it is preferred to return by RETFIE instruction. 
+
+	return;
+}
+
+void __attribute__( ( interrupt, no_auto_psv ) ) _StackError( void )
+{
+	INTCON1bits.STKERR = 0; //Clear the trap flag
+
+	return;
+}
+
+void __attribute__( ( interrupt, no_auto_psv ) ) _MathError( void )
+{
+	INTCON1bits.MATHERR = 0; //Clear the trap flag
+
+	return;
+}
+
+#endif

--- a/EMMS_Code_CommandBoard.X/common.h
+++ b/EMMS_Code_CommandBoard.X/common.h
@@ -77,6 +77,14 @@
 #    define LEDS_FOR_DEBUG false
 // set this to 'true' to turn off the LED graph and enable "Test" LEDs for testing purposes
 
+// Error Trap Interrupts
+// when true - this will hide most memory errors
+// just hiding the error is not good as there could be bigger underlying problems which cause other issues
+// this should only be set to true for production builds
+// if there is a reset error, these traps can also be used to find what is causing it by setting a breakpoint and debugging the program line-by-line
+#    define ERROR_TRAP_INTERRUPTS_ACTIVE false
+
+
 #    define CHAR_NULL '\0'   //yes, used in many many places
 
 /****************


### PR DESCRIPTION
Added error trap interrupts.
These error traps keep the meter from resetting when a error is encountered.
They simply clear the interrupt flag and return to the next line from where the error occurred.
This could result in corrupted data, but it keeps the meter from resetting.
Most of the time the corrupted data will work itself out.