### PR TITLE
Feature - IDE Debug Mode

### DIFF
--- a/EMMS_Code_CommandBoard.X/-CL_CommandBoard.txt
+++ b/EMMS_Code_CommandBoard.X/-CL_CommandBoard.txt
@@ -74,6 +74,22 @@ CURRENT STATUS
  UI last power failure - not working right now
 
 
+12/3/2021	TBA
+***************
+	Feature
+		Error Trap Interrupts
+		Captures most errors which cause a meter reset
+		Simply clears the error and continues where it left off
+		Potential that corrupted data is introduced, but should clear itself out
+	Feature
+		IDE Debug Mode
+		One can now use the debug mode of the IDE to debug the program
+		This allows viewing of memory and variables and stepping the program line by line
+		requires that UART2 be disconnected and completely removed from the program code as the UART TX and RX are used by the debugger PICKit
+
+
+
+
 11/26/2021  TBA
 **************
     BugFix

--- a/EMMS_Code_CommandBoard.X/MasterComm.c
+++ b/EMMS_Code_CommandBoard.X/MasterComm.c
@@ -85,7 +85,9 @@ enum communications_port_enum
 {
 	enum_port_commSPI,
 	enum_port_commUART1,
+#if UART2_ENABLE == true
 	enum_port_commUART2,
+#endif
 };
 
 struct buffer_struct
@@ -128,8 +130,11 @@ bool SPI_send_data_char( char data );
 bool UART1_receive_data_char( char * );
 bool UART1_receive_all_data_char( char *data );
 bool UART1_send_data_char( char data );
+
+#if UART2_ENABLE == true
 bool UART2_receive_data_char( char * );
 bool UART2_send_data_char( char data );
+#endif
 
 bool strmatch( char* a, char* b );
 int strcmp2( char* a, char* b );
@@ -146,13 +151,21 @@ void send_end_of_transmission( struct buffer_struct *send_buffer );
 
 void communicationsSPI( bool initialize );
 void communicationsUART1( bool initialize );
+
+#if UART2_ENABLE == true
 void communicationsUART2( bool initialize );
+#endif
+
 bool communicationsRecv( struct buffer_struct *receive_buffer, struct buffer_struct *send_buffer, enum communications_port_enum communicationsPort, enum receive_status_enum *receive_current_state );
 bool communicationsSend( struct buffer_struct *send_buffer, enum communications_port_enum communicationsPort );
 
 void uartInit( void );
 void commSPIInit( void );
+
+#if UART2_ENABLE == true
 void initUART2( void );
+#endif
+
 void initUART1( void );
 
 bool xSumCheck( char* check_buffer );
@@ -177,7 +190,10 @@ void commInit( )
 	communicationsSPI( initialize );
 
 	communicationsUART1( initialize );
+
+#if UART2_ENABLE == true
 	communicationsUART2( initialize );
+#endif
 
 }
 
@@ -192,7 +208,10 @@ void commRunRoutine( )
 	communicationsSPI( initialize );
 
 	communicationsUART1( initialize ); // This one works (Lower RJ45)
+
+#if UART2_ENABLE == true
 	communicationsUART2( initialize ); // This one no worky (Upper RJ45)
+#endif
 
 	return;
 
@@ -388,6 +407,7 @@ void communicationsUART1( bool initialize )
 	return;
 }
 
+#if UART2_ENABLE == true
 // Handles the UART functionality for UART2, for the the initial and the continuous running processes
 
 void communicationsUART2( bool initialize )
@@ -437,6 +457,8 @@ void communicationsUART2( bool initialize )
 
 	return;
 }
+#endif
+
 
 // Will check if the Checksum in a message is accurate to ensure accuracy
 
@@ -526,9 +548,13 @@ bool communicationsRecv( struct buffer_struct *receive_buffer, struct buffer_str
 		case enum_port_commUART1:
 			gotSomething = UART1_receive_data_char( &data );
 			break;
+
+#if UART2_ENABLE == true
 		case enum_port_commUART2:
 			gotSomething = UART2_receive_data_char( &data );
 			break;
+#endif
+
 	}
 
 	if( gotSomething == true )
@@ -590,9 +616,13 @@ bool communicationsSend( struct buffer_struct *send_buffer, enum communications_
 
 				data_sent = UART1_send_data_char( send_buffer->data_buffer[send_buffer->read_position] );
 				break;
+
+#if UART2_ENABLE == true
 			case enum_port_commUART2:
 				data_sent = UART2_send_data_char( send_buffer->data_buffer[send_buffer->read_position] );
 				break;
+#endif
+
 		}
 		if( data_sent == true )
 		{
@@ -1641,6 +1671,8 @@ bool UART1_send_data_char( char data )
 	return sendGood;
 }
 
+#if UART2_ENABLE == true
+
 bool UART2_receive_data_char( char *data )
 {
 	bool recvGood = false;
@@ -1668,7 +1700,7 @@ bool UART2_send_data_char( char data )
 
 	return sendGood;
 }
-
+#endif
 
 /************************/
 // RESPONSES
@@ -1738,9 +1770,14 @@ void uartInit( void )
 {
 
 	initUART1( );
+
+#if UART2_ENABLE == true
 	initUART2( );
+#endif
 
 }
+
+#if UART2_ENABLE == true
 
 void initUART2( void )
 {
@@ -1802,6 +1839,7 @@ void initUART2( void )
 
 	return;
 }
+#endif
 
 void initUART1( void )
 {

--- a/EMMS_Code_CommandBoard.X/PowerMain.c
+++ b/EMMS_Code_CommandBoard.X/PowerMain.c
@@ -140,13 +140,53 @@ int main( void )
 	ANSA = 0b0000000000000000;
 	ANSB = 0b0000000000000000;
 
+
 	// set all ports as input by default
 	TRISA = 0b1111111111111111; // this is equivalent to setting all of the individual bits
+
+#if IDE_DEBUG_ENABLE == true
+	// need to leave B0 and B1 alone for debug mode
+	TRISBbits.TRISB2 = 1;
+	TRISBbits.TRISB3 = 1;
+	TRISBbits.TRISB4 = 1;
+	TRISBbits.TRISB5 = 1;
+	TRISBbits.TRISB6 = 1;
+	TRISBbits.TRISB7 = 1;
+	TRISBbits.TRISB8 = 1;
+	TRISBbits.TRISB9 = 1;
+	TRISBbits.TRISB10 = 1;
+	TRISBbits.TRISB11 = 1;
+	TRISBbits.TRISB12 = 1;
+	TRISBbits.TRISB13 = 1;
+	TRISBbits.TRISB14 = 1;
+	TRISBbits.TRISB15 = 1;
+#else
 	TRISB = 0b1111111111111111; // 0b1111111111111111 = 0xFFFF
+#endif	
+
 
 	// set all ports to low by default to start
 	PORTA = 0b0000000000000000; // this is equivalent to setting all of the individual bits
+#if IDE_DEBUG_ENABLE == true
+	// need to leave B0 and B1 alone for debug mode
+	PORTBbits.RB2 = 0;
+	PORTBbits.RB3 = 0;
+	PORTBbits.RB4 = 0;
+	PORTBbits.RB5 = 0;
+	PORTBbits.RB6 = 0;
+	PORTBbits.RB7 = 0;
+	PORTBbits.RB8 = 0;
+	PORTBbits.RB9 = 0;
+	PORTBbits.RB10 = 0;
+	PORTBbits.RB11 = 0;
+	PORTBbits.RB12 = 0;
+	PORTBbits.RB13 = 0;
+	PORTBbits.RB14 = 0;
+	PORTBbits.RB15 = 0;
+#else
 	PORTB = 0b0000000000000000; // 0b0000000000000000 = 0
+#endif
+
 
 	ledInit( );
 

--- a/EMMS_Code_CommandBoard.X/common.h
+++ b/EMMS_Code_CommandBoard.X/common.h
@@ -71,18 +71,52 @@
  do not include macros that are only used internally within this module
  ****************/
 
+/***********************
+	LEDS for debugging
+	disables normal program LED use (for the power remaining bar graph)
+	allows LED testing functions to be used
+	set this to 'true' to turn off the LED graph and enable "Test" LEDs for testing purposes
+ *************************/
 
-// LEDs for power remaining indicator
-// can also be used for debugging
 #    define LEDS_FOR_DEBUG false
-// set this to 'true' to turn off the LED graph and enable "Test" LEDs for testing purposes
 
-// Error Trap Interrupts
-// when true - this will hide most memory errors
-// just hiding the error is not good as there could be bigger underlying problems which cause other issues
-// this should only be set to true for production builds
-// if there is a reset error, these traps can also be used to find what is causing it by setting a breakpoint and debugging the program line-by-line
+
+/******************
+	Error Trap Interrupts
+	when true - this will hide most memory errors
+	just hiding the error is not good as there could be bigger underlying problems which cause other issues
+	this should only be set to true for production builds
+	if there is a reset error, these traps can also be used to find what is causing it by setting a breakpoint and debugging the program line-by-line
+ *****************/
 #    define ERROR_TRAP_INTERRUPTS_ACTIVE false
+
+/***********************
+	IDE Debug Mode
+	Allows the MPLAB X IDE to be run in debugging mode
+		view memory
+		view variable values
+		step the program line-by-line
+	Requires PIC24 pins 4 & 5 - shared pins with other functions
+		UART2 TX & RX
+		RB0 and RB1 general input/output
+		PGED1 and PGEC1 programming pins (required for debugging)
+	UART2 cannot be used
+		this is the top port on the CommandBoard PCB
+		The MAX488 chip cannot be installed for this port (top chip location)
+		If it is installed, traces must be cut to disconnect the chip from PIC pins 4 & 5 must be cut
+	All UART2 code must be removed from the compile
+ 
+	Set IDE_DEBUG_ENABLE to true to disable UART2 and enable debug mode
+		UART2_ENABLE is set automatically
+ ************************/
+#    define IDE_DEBUG_ENABLE false
+
+#    if IDE_DEBUG_ENABLE == true
+#        define UART2_ENABLE false
+#    else
+#        define UART2_ENABLED true
+#    endif
+
 
 
 #    define CHAR_NULL '\0'   //yes, used in many many places


### PR DESCRIPTION
One can now use the debug mode of the IDE to debug the program
This allows viewing of memory and variables and stepping the program line by line
requires that UART2 be disconnected and completely removed from the program code as the UART TX and RX are used by the debugger PICKit