### PR TITLE
TBA_Bugfix-CompileError

### DIFF
--- a/EMMS_Code_CommandBoard.X/RTCC.h
+++ b/EMMS_Code_CommandBoard.X/RTCC.h
@@ -39,6 +39,7 @@ void rtccI2CReadPowerTimes( struct date_time *timePowerFail, struct date_time *t
 void rtccI2CReadTime( struct date_time *readDateTime );
 void rtccI2CSetTime( struct date_time *setDateTime );
 
+void getResetTimes( struct date_time *timeFail, struct date_time *timeRestore );
 
 
 

--- a/EMMS_Code_CommandBoard.X/nbproject/configurations.xml
+++ b/EMMS_Code_CommandBoard.X/nbproject/configurations.xml
@@ -265,7 +265,7 @@
         <property key="programoptions.preservedataflash" value="false"/>
         <property key="programoptions.preservedataflash.ranges"
                   value="${memories.dataflash.default}"/>
-        <property key="programoptions.preserveeeprom" value="false"/>
+        <property key="programoptions.preserveeeprom" value="true"/>
         <property key="programoptions.preserveeeprom.ranges" value="7ffe00-7fffff"/>
         <property key="programoptions.preserveprogram.ranges" value=""/>
         <property key="programoptions.preserveprogramrange" value="false"/>


### PR DESCRIPTION
There was a compile error where getResetTimes was implicitly defined.
The build would still succeed and the program likely ran OK since the function did exist in another .c file.

This is now added to RTCC.h to eliminate the compile error.