### PR TITLE
Bugfix - Baud Rate

### DIFF
--- a/EMMS_Code_CommandBoard.X/common.h
+++ b/EMMS_Code_CommandBoard.X/common.h
@@ -78,7 +78,7 @@
 	set this to 'true' to turn off the LED graph and enable "Test" LEDs for testing purposes
  *************************/
 
-#    define LEDS_FOR_DEBUG false
+#    define LEDS_FOR_DEBUG true
 
 
 /******************

--- a/EMMS_Code_CommandBoard.X/nbproject/configurations.xml
+++ b/EMMS_Code_CommandBoard.X/nbproject/configurations.xml
@@ -685,7 +685,7 @@
         <property key="programoptions.preservedataflash" value="false"/>
         <property key="programoptions.preservedataflash.ranges"
                   value="${memories.dataflash.default}"/>
-        <property key="programoptions.preserveeeprom" value="true"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
         <property key="programoptions.preserveeeprom.ranges" value="7ffe00-7fffff"/>
         <property key="programoptions.preserveprogram.ranges" value=""/>
         <property key="programoptions.preserveprogramrange" value="false"/>
@@ -742,6 +742,8 @@
                   value="${communication.interface.default}"/>
         <property key="communication.interface.jtag" value="2wire"/>
         <property key="communication.speed" value="${communication.speed.default}"/>
+        <property key="debugoptions.debug-startup" value="Use system settings"/>
+        <property key="debugoptions.reset-behaviour" value="Use system settings"/>
         <property key="debugoptions.simultaneous.debug" value="false"/>
         <property key="debugoptions.useswbreakpoints" value="false"/>
         <property key="freeze.timers" value="false"/>
@@ -773,7 +775,7 @@
         <property key="programoptions.preservedataflash" value="false"/>
         <property key="programoptions.preservedataflash.ranges"
                   value="${memories.dataflash.default}"/>
-        <property key="programoptions.preserveeeprom" value="true"/>
+        <property key="programoptions.preserveeeprom" value="false"/>
         <property key="programoptions.preserveeeprom.ranges" value="7ffe00-7fffff"/>
         <property key="programoptions.preserveprogram.ranges" value=""/>
         <property key="programoptions.preserveprogramrange" value="false"/>


### PR DESCRIPTION
Bug
    The high UART baud rate 115200 was interfering with SPI communication
    Lowered to 19200 - this equates to 1920 chars / sec. Plenty fast enough.
    The lower baud rate results in faster comms because there are less timing errors